### PR TITLE
Fix testing bug preventing any tests from running

### DIFF
--- a/internal/pipeline_test.go
+++ b/internal/pipeline_test.go
@@ -27,7 +27,7 @@ func TestDeployments(t *testing.T) {
 		} else if root == path {
 			return nil
 		} else if !strings.HasSuffix(path, ".test") {
-			return fs.SkipDir
+			return nil
 		} else {
 			absPath, err := filepath.Abs(path)
 			if err != nil {


### PR DESCRIPTION
The bug is that while walking over the "/test" directory, we ignore directories that DO NOT end with ".test" by skipping them entirely, instead of just avoiding to treat them as subtests.

The fix is simply to still walk such directories (that do not end with `.test` suffix) but only run a subtest for directories that end with that suffix.