### PR TITLE
Fix importing local directory resources

### DIFF
--- a/test/local-resources/import-kude-dir.test/expected.yaml
+++ b/test/local-resources/import-kude-dir.test/expected.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    foo: bar2
+    foo2: bar2
+  labels:
+    app.kubernetes.io/component: test
+  name: test
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: test
+    spec:
+      containers:
+        - image: test/test
+          name: server
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    foo: bar2
+  labels:
+    app.kubernetes.io/component: test
+  name: test
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+  selector:
+    app.kubernetes.io/component: test
+  type: ClusterIP

--- a/test/local-resources/import-kude-dir.test/kude.yaml
+++ b/test/local-resources/import-kude-dir.test/kude.yaml
@@ -1,0 +1,10 @@
+apiVersion: kude.kfirs.com/v1alpha1
+kind: Pipeline
+resources:
+  - ../kude-deployment-dir
+  - service.yaml
+pipeline:
+  - image: ghcr.io/arikkfir/kude/functions/annotate:test
+    config:
+      name: foo
+      value: bar2

--- a/test/local-resources/import-kude-dir.test/service.yaml
+++ b/test/local-resources/import-kude-dir.test/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: test
+  name: test
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+  selector:
+    app.kubernetes.io/component: test
+  type: ClusterIP

--- a/test/local-resources/import-normal-dir.test/expected.yaml
+++ b/test/local-resources/import-normal-dir.test/expected.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    foo: bar2
+  labels:
+    app.kubernetes.io/component: test
+  name: test
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: test
+    spec:
+      containers:
+        - image: test/test
+          name: server
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    foo: bar2
+  labels:
+    app.kubernetes.io/component: test
+  name: test
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+  selector:
+    app.kubernetes.io/component: test
+  type: ClusterIP

--- a/test/local-resources/import-normal-dir.test/kude.yaml
+++ b/test/local-resources/import-normal-dir.test/kude.yaml
@@ -1,0 +1,10 @@
+apiVersion: kude.kfirs.com/v1alpha1
+kind: Pipeline
+resources:
+  - ../not-kude-deployment-dir
+  - service.yaml
+pipeline:
+  - image: ghcr.io/arikkfir/kude/functions/annotate:test
+    config:
+      name: foo
+      value: bar2

--- a/test/local-resources/import-normal-dir.test/service.yaml
+++ b/test/local-resources/import-normal-dir.test/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: test
+  name: test
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+  selector:
+    app.kubernetes.io/component: test
+  type: ClusterIP

--- a/test/local-resources/import-normal-file.test/expected.yaml
+++ b/test/local-resources/import-normal-file.test/expected.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    foo: bar2
+  labels:
+    app.kubernetes.io/component: test
+  name: test
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: test
+    spec:
+      containers:
+        - image: test/test
+          name: server
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    foo: bar2
+  labels:
+    app.kubernetes.io/component: test
+  name: test
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+  selector:
+    app.kubernetes.io/component: test
+  type: ClusterIP

--- a/test/local-resources/import-normal-file.test/kude.yaml
+++ b/test/local-resources/import-normal-file.test/kude.yaml
@@ -1,0 +1,10 @@
+apiVersion: kude.kfirs.com/v1alpha1
+kind: Pipeline
+resources:
+  - ../not-kude-deployment-dir/deployment.yaml
+  - service.yaml
+pipeline:
+  - image: ghcr.io/arikkfir/kude/functions/annotate:test
+    config:
+      name: foo
+      value: bar2

--- a/test/local-resources/import-normal-file.test/service.yaml
+++ b/test/local-resources/import-normal-file.test/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: test
+  name: test
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+  selector:
+    app.kubernetes.io/component: test
+  type: ClusterIP

--- a/test/local-resources/kude-deployment-dir/deployment.yaml
+++ b/test/local-resources/kude-deployment-dir/deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: test
+  name: test
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: test
+    spec:
+      containers:
+        - image: test/test
+          name: server
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP

--- a/test/local-resources/kude-deployment-dir/kude.yaml
+++ b/test/local-resources/kude-deployment-dir/kude.yaml
@@ -1,0 +1,13 @@
+apiVersion: kude.kfirs.com/v1alpha1
+kind: Pipeline
+resources:
+  - deployment.yaml
+pipeline:
+  - image: ghcr.io/arikkfir/kude/functions/annotate:test
+    config:
+      name: foo
+      value: bar
+  - image: ghcr.io/arikkfir/kude/functions/annotate:test
+    config:
+      name: foo2
+      value: bar2

--- a/test/local-resources/not-kude-deployment-dir/deployment.yaml
+++ b/test/local-resources/not-kude-deployment-dir/deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: test
+  name: test
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: test
+    spec:
+      containers:
+        - image: test/test
+          name: server
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP


### PR DESCRIPTION
Local resources import failed due to three bugs:
1. Infinite hang caused by a missing closure of a pipe writer, before attempting to read from it. This caused the subsequent reader of the pipe never to receive an EOF, hence hanging indefinitely.

2. The `go-getter` library failed "downloading" local resource URLs (both directories and files) because it attempted to create a symlink to the local resource where the target directory already existed.

   The solution is simply to first detect local URLs via `getter.Detect`
   function, and if the source URL is indeed a local URL, provide a
   non-existent target directory when calling `getter.GetAny`.

3. Since `go-getter` creates a symlink for local resources, processing them failed to actually read those resources, because the Golang directory traversal functions (`filepath.WalkDir`) do not follow symlinks.

   The solution is to detect symlinks while traversing directories and
   manually traverse their targets.

This commit also refactors the `stream` struct and simplifies it by merging the `downloadAndAddFile` and `downloadAndAddDirectory` functions into the `Add` function.