### PR TITLE
Fix importing remote resources

### DIFF
--- a/internal/stream.go
+++ b/internal/stream.go
@@ -28,12 +28,7 @@ func (s *stream) Close() error {
 }
 
 func (s *stream) Add(url string) error {
-	safeLocalName := url
-	safeLocalName = strings.ReplaceAll(safeLocalName, ".", "${dot}")
-	safeLocalName = strings.ReplaceAll(safeLocalName, "/", "${bckslash}")
-	safeLocalName = strings.ReplaceAll(safeLocalName, ":", "${colon}")
-	safeLocalName = strings.ReplaceAll(safeLocalName, "\\", "${fwdslash}")
-	tempDir, err := ioutil.TempDir("", safeLocalName+".*")
+	tempDir, err := ioutil.TempDir("", "")
 	if err != nil {
 		return fmt.Errorf("failed to create temp directory: %w", err)
 	}

--- a/test/remoe-resources/import-github-kude-dir.test/expected.yaml
+++ b/test/remoe-resources/import-github-kude-dir.test/expected.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    foo: bar3
+    foo2: bar2
+  labels:
+    app.kubernetes.io/component: test
+  name: test
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: test
+    spec:
+      containers:
+        - image: test/test
+          name: server
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    foo: bar3
+  labels:
+    app.kubernetes.io/component: test
+  name: test
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+  selector:
+    app.kubernetes.io/component: test
+  type: ClusterIP

--- a/test/remoe-resources/import-github-kude-dir.test/kude.yaml
+++ b/test/remoe-resources/import-github-kude-dir.test/kude.yaml
@@ -1,0 +1,10 @@
+apiVersion: kude.kfirs.com/v1alpha1
+kind: Pipeline
+resources:
+  - github.com/arikkfir/kude//test/local-resources/kude-deployment-dir?ref=main
+  - service.yaml
+pipeline:
+  - image: ghcr.io/arikkfir/kude/functions/annotate:test
+    config:
+      name: foo
+      value: bar3

--- a/test/remoe-resources/import-github-kude-dir.test/service.yaml
+++ b/test/remoe-resources/import-github-kude-dir.test/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: test
+  name: test
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+  selector:
+    app.kubernetes.io/component: test
+  type: ClusterIP


### PR DESCRIPTION
Fix importing of remote resources, by using safe non-specific local file names, without error-prone escaping rules.