### PR TITLE
Avoid using "internal" code in functions containers

### DIFF
--- a/cmd/functions/annotate/Dockerfile
+++ b/cmd/functions/annotate/Dockerfile
@@ -14,7 +14,6 @@ RUN go mod download
 
 # Now build the actual executable
 COPY cmd ./cmd
-COPY internal ./internal
 COPY pkg ./pkg
 ENV CGO_ENABLED="0"
 ENV GOARCH="amd64"

--- a/cmd/functions/label/Dockerfile
+++ b/cmd/functions/label/Dockerfile
@@ -14,7 +14,6 @@ RUN go mod download
 
 # Now build the actual executable
 COPY cmd ./cmd
-COPY internal ./internal
 COPY pkg ./pkg
 ENV CGO_ENABLED="0"
 ENV GOARCH="amd64"


### PR DESCRIPTION
This change stops copying the "internal" package into the functions Docker images when building functions.

This ensures that we do not depend on internal code in the stock functions.