### PR TITLE
Optimize functions Docker image build

### DIFF
--- a/cmd/functions/annotate/Dockerfile
+++ b/cmd/functions/annotate/Dockerfile
@@ -13,13 +13,13 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 # Now build the actual executable
-COPY cmd ./cmd
+ARG function
+COPY cmd/functions/${function} ./cmd/functions/${function}
 COPY pkg ./pkg
 ENV CGO_ENABLED="0"
 ENV GOARCH="amd64"
 ENV GOOS="linux"
 ENV GO111MODULE="on"
-ARG function
 RUN go build -o function ./cmd/functions/${function}/main.go
 
 ### Target layer

--- a/cmd/functions/label/Dockerfile
+++ b/cmd/functions/label/Dockerfile
@@ -13,13 +13,13 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 # Now build the actual executable
-COPY cmd ./cmd
+ARG function
+COPY cmd/functions/${function} ./cmd/functions/${function}
 COPY pkg ./pkg
 ENV CGO_ENABLED="0"
 ENV GOARCH="amd64"
 ENV GOOS="linux"
 ENV GO111MODULE="on"
-ARG function
 RUN go build -o function ./cmd/functions/${function}/main.go
 
 ### Target layer

--- a/cmd/functions/secret/Dockerfile
+++ b/cmd/functions/secret/Dockerfile
@@ -13,13 +13,13 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 # Now build the actual executable
-COPY cmd ./cmd
+ARG function
+COPY cmd/functions/${function} ./cmd/functions/${function}
 COPY pkg ./pkg
 ENV CGO_ENABLED="0"
 ENV GOARCH="amd64"
 ENV GOOS="linux"
 ENV GO111MODULE="on"
-ARG function
 RUN go build -o function ./cmd/functions/${function}/main.go
 
 ### Target layer


### PR DESCRIPTION
For each function Dockerfile, only copy the `cmd/functions/<function>` path, without the other functions. This ensures that changes in one function do not cause a rebuild for other functions.