### PR TITLE
Make the "Secret#type" field implicit when not set

### DIFF
--- a/cmd/functions/secret/main.go
+++ b/cmd/functions/secret/main.go
@@ -15,7 +15,6 @@ import (
 )
 
 func main() {
-	viper.SetDefault("type", "Opaque")
 	pkg.Configure()
 
 	// Read configuration file
@@ -72,13 +71,18 @@ func main() {
 				yaml.Tee(yaml.SetField(yaml.KindField, yaml.NewScalarRNode("Secret"))),
 				yaml.Tee(yaml.SetK8sName(hashedName)),
 				yaml.Tee(yaml.SetAnnotation(pkg.PreviousNameAnnotationName, viper.GetString("name"))),
-				yaml.Tee(yaml.SetField("type", yaml.NewScalarRNode(viper.GetString("type")))),
 				yaml.Tee(yaml.SetField("data", yaml.NewMapRNode(&data))),
 			)
 			if err != nil {
 				return nil, fmt.Errorf("error generating secret: %w", err)
 			}
-			if viper.GetString("namespace") != "" {
+			if viper.IsSet("type") {
+				err := node.PipeE(yaml.SetField("type", yaml.NewScalarRNode(viper.GetString("type"))))
+				if err != nil {
+					return nil, fmt.Errorf("error generating secret: %w", err)
+				}
+			}
+			if viper.IsSet("namespace") {
 				err := node.PipeE(yaml.Tee(yaml.SetK8sNamespace(viper.GetString("namespace"))))
 				if err != nil {
 					return nil, fmt.Errorf("error generating secret: %w", err)

--- a/test/secrets/generate-secret.test/expected.yaml
+++ b/test/secrets/generate-secret.test/expected.yaml
@@ -40,3 +40,14 @@ metadata:
     numericAnn: "123"
   name: mysecret-0f6c5d02114253073f6b80c7bbcbba27548715e8
 type: Opaque
+---
+apiVersion: v1
+data:
+  foopath: YmFy
+  fooval: YmFy
+kind: Secret
+metadata:
+  annotations:
+    kude.kfirs.com/previous-name: implicitly-opaque-mysecret
+    numericAnn: "123"
+  name: implicitly-opaque-mysecret-0f6c5d02114253073f6b80c7bbcbba27548715e8

--- a/test/secrets/generate-secret.test/kude.yaml
+++ b/test/secrets/generate-secret.test/kude.yaml
@@ -12,6 +12,14 @@ pipeline:
           value: bar
         - key: foopath
           path: secretfile
+  - image: ghcr.io/arikkfir/kude/functions/secret:test
+    config:
+      name: implicitly-opaque-mysecret
+      contents:
+        - key: fooval
+          value: bar
+        - key: foopath
+          path: secretfile
   - image: ghcr.io/arikkfir/kude/functions/annotate:test
     config:
       name: numericAnn


### PR DESCRIPTION
The "type" field of the "Secret" object should not be set, if not explicitly provided in the "secret" function configuration.