### PR TITLE
Add "helm" function

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -29,6 +29,7 @@
         <method importPath="github.com/arikkfir/kude/internal" receiver="*stream" name="Close" />
         <method importPath="github.com/arikkfir/kude/internal/stream" receiver="Stream" name="Close" />
         <method importPath="sigs.k8s.io/kustomize/kyaml/internal/forked/github.com/go-yaml/yaml" receiver="*Encoder" name="Close" />
+        <method importPath="compress/gzip" receiver="*Reader" name="Close" />
       </methods>
     </inspection_tool>
   </profile>

--- a/cmd/functions/helm/Dockerfile
+++ b/cmd/functions/helm/Dockerfile
@@ -1,0 +1,34 @@
+########################################################################################################################
+# NOTES:
+#   1. This Dockerfile is meant to be run in the root directory of this repository
+########################################################################################################################
+
+### Build executable
+FROM golang:1.17 as builder
+WORKDIR /workspace
+
+# Copy the Go manifests, download dependencies & cache them before building and copying actual source code, so when
+# source code changes, downloaded dependencies stay cached and are not downloaded again (unless manifest changes too.)
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Now build the actual executable
+ARG function
+COPY cmd/functions/${function} ./cmd/functions/${function}
+COPY pkg ./pkg
+ENV CGO_ENABLED="0"
+ENV GOARCH="amd64"
+ENV GOOS="linux"
+ENV GO111MODULE="on"
+RUN go build -o function ./cmd/functions/${function}/main.go
+
+### Target layer
+FROM gcr.io/distroless/base:latest
+WORKDIR /
+COPY --from=builder /workspace/function ./function
+ENV GOTRACEBACK=all
+ENTRYPOINT ["/function"]
+
+### Labels
+LABEL "kude.kfirs.com/minimum-version"=0.0.0
+LABEL "kude.kfirs.com/mount:1"="$.path"

--- a/cmd/functions/helm/main.go
+++ b/cmd/functions/helm/main.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"github.com/arikkfir/kude/pkg"
+	"github.com/spf13/viper"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"strings"
+)
+
+func downloadHelmArchive(localHelmArchive string) error {
+	url := fmt.Sprintf("https://get.helm.sh/%s", filepath.Base(localHelmArchive))
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to download helm: %w", err)
+	}
+	defer resp.Body.Close()
+
+	out, err := os.Create(localHelmArchive)
+	if err != nil {
+		return fmt.Errorf("failed to create helm file at '%s': %w", localHelmArchive, err)
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to write helm file to '%s': %w", localHelmArchive, err)
+	}
+	return nil
+}
+
+func extractHelm(arch, helmArchiveFile, helmFile string) error {
+	r, err := os.Open(helmArchiveFile)
+	if err != nil {
+		return fmt.Errorf("failed to open helm archive '%s': %w", helmArchiveFile, err)
+	}
+	defer r.Close()
+
+	gr, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("failed to create gzip reader for helm archive '%s': %w", helmArchiveFile, err)
+	}
+	defer gr.Close()
+
+	tr := tar.NewReader(gr)
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			} else {
+				return fmt.Errorf("failed to read next entry from helm archive '%s': %w", helmArchiveFile, err)
+			}
+		}
+
+		if hdr.Name == arch+"/helm" {
+			w, err := os.Create(helmFile)
+			if err != nil {
+				return fmt.Errorf("failed to create helm file '%s': %w", helmFile, err)
+			} else if err := os.Chmod(helmFile, 0755); err != nil {
+				return fmt.Errorf("failed to chmod helm file '%s': %w", helmFile, err)
+			}
+
+			_, err = io.Copy(w, tr)
+			if err != nil {
+				return fmt.Errorf("failed to write helm file '%s': %w", helmFile, err)
+			}
+			w.Close()
+			break
+		}
+	}
+	return nil
+}
+
+func main() {
+	viper.SetDefault("workspace", "/workspace/temp")
+	viper.SetDefault("arch", "linux-amd64")
+	viper.SetDefault("helm-version", "v3.8.1")
+	pkg.Configure()
+
+	root := viper.GetString("workspace")
+	arch := viper.GetString("arch")
+
+	helmVersion := viper.GetString("helm-version")
+	if helmVersion == "" {
+		panic(fmt.Errorf("helm version is not set"))
+	} else if strings.HasPrefix(helmVersion, "v") {
+		helmVersion = helmVersion[1:]
+	}
+
+	helmFile := filepath.Join(root, "helm")
+	if _, err := os.Stat(helmFile); err != nil {
+		if os.IsNotExist(err) {
+
+			helmArchiveFile := filepath.Join(root, "helm-v"+helmVersion+"-"+arch+".tar.gz")
+			if _, err := os.Stat(helmArchiveFile); err != nil {
+				if os.IsNotExist(err) {
+					err := downloadHelmArchive(helmArchiveFile)
+					if err != nil {
+						panic(err)
+					}
+				} else {
+					panic(err)
+				}
+			}
+
+			if err := extractHelm(arch, helmArchiveFile, helmFile); err != nil {
+				panic(err)
+			}
+		} else {
+			panic(err)
+		}
+	}
+
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+
+	var args = viper.GetStringSlice("args")
+	cmd := exec.Command(helmFile, args...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = pw
+	if viper.IsSet("path") {
+		cmd.Dir = filepath.Join(root, viper.GetString("path"))
+	}
+	err = cmd.Run()
+	if err != nil {
+		panic(err)
+	}
+	pw.Close()
+
+	pipeline := kio.Pipeline{
+		Inputs: []kio.Reader{
+			&kio.ByteReader{Reader: os.Stdin},
+			&kio.ByteReader{Reader: pr},
+		},
+		Filters: []kio.Filter{},
+		Outputs: []kio.Writer{kio.ByteWriter{Writer: os.Stdout}},
+	}
+	if err := pipeline.Execute(); err != nil {
+		panic(err)
+	}
+}

--- a/test/helm/helm-remote-chart-only.test/expected.yaml
+++ b/test/helm/helm-remote-chart-only.test/expected.yaml
@@ -1,0 +1,106 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: helm-remote-chart-podinfo
+    app.kubernetes.io/version: 6.1.0
+    helm.sh/chart: podinfo-6.1.0
+  name: helm-remote-chart-podinfo
+spec:
+  ports:
+    - name: http
+      port: 9898
+      protocol: TCP
+      targetPort: http
+    - name: grpc
+      port: 9999
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: helm-remote-chart-podinfo
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: helm-remote-chart-podinfo
+    app.kubernetes.io/version: 6.1.0
+    helm.sh/chart: podinfo-6.1.0
+  name: helm-remote-chart-podinfo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: helm-remote-chart-podinfo
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "9898"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: helm-remote-chart-podinfo
+    spec:
+      containers:
+        - command:
+            - ./podinfo
+            - --port=9898
+            - --cert-path=/data/cert
+            - --port-metrics=9797
+            - --grpc-port=9999
+            - --grpc-service-name=podinfo
+            - --level=info
+            - --random-delay=false
+            - --random-error=false
+          env:
+            - name: PODINFO_UI_COLOR
+              value: '#34577c'
+          image: ghcr.io/stefanprodan/podinfo:6.1.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+                - podcli
+                - check
+                - http
+                - localhost:9898/healthz
+            initialDelaySeconds: 1
+            timeoutSeconds: 5
+          name: podinfo
+          ports:
+            - containerPort: 9898
+              name: http
+              protocol: TCP
+            - containerPort: 9797
+              name: http-metrics
+              protocol: TCP
+            - containerPort: 9999
+              name: grpc
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - podcli
+                - check
+                - http
+                - localhost:9898/readyz
+            initialDelaySeconds: 1
+            timeoutSeconds: 5
+          resources:
+            limits: null
+            requests:
+              cpu: 1m
+              memory: 16Mi
+          volumeMounts:
+            - mountPath: /data
+              name: data
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir: {}
+          name: data

--- a/test/helm/helm-remote-chart-only.test/kude.yaml
+++ b/test/helm/helm-remote-chart-only.test/kude.yaml
@@ -1,0 +1,18 @@
+apiVersion: kude.kfirs.com/v1alpha1
+kind: Pipeline
+pipeline:
+  - image: ghcr.io/arikkfir/kude/functions/helm:test
+    network: true
+    config:
+      helm-version: 3.8.1
+      args:
+        - template
+        - helm-remote-chart
+        - podinfo
+        - --create-namespace
+        - --description=Test Helm Remote Chart
+        - --include-crds
+        - --namespace=test
+        - --repo=https://stefanprodan.github.io/podinfo
+        - --skip-tests
+        - --version=6.1.0

--- a/test/helm/helm-remote-chart.test/deployment.yaml
+++ b/test/helm/helm-remote-chart.test/deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: test
+  name: test
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: test
+    spec:
+      containers:
+        - image: test/test
+          name: server
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP

--- a/test/helm/helm-remote-chart.test/expected.yaml
+++ b/test/helm/helm-remote-chart.test/expected.yaml
@@ -1,0 +1,129 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: test
+  name: test
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: test
+    spec:
+      containers:
+        - image: test/test
+          name: server
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: helm-remote-chart-podinfo
+    app.kubernetes.io/version: 6.1.0
+    helm.sh/chart: podinfo-6.1.0
+  name: helm-remote-chart-podinfo
+spec:
+  ports:
+    - name: http
+      port: 9898
+      protocol: TCP
+      targetPort: http
+    - name: grpc
+      port: 9999
+      protocol: TCP
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: helm-remote-chart-podinfo
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: helm-remote-chart-podinfo
+    app.kubernetes.io/version: 6.1.0
+    helm.sh/chart: podinfo-6.1.0
+  name: helm-remote-chart-podinfo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: helm-remote-chart-podinfo
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "9898"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: helm-remote-chart-podinfo
+    spec:
+      containers:
+        - command:
+            - ./podinfo
+            - --port=9898
+            - --cert-path=/data/cert
+            - --port-metrics=9797
+            - --grpc-port=9999
+            - --grpc-service-name=podinfo
+            - --level=info
+            - --random-delay=false
+            - --random-error=false
+          env:
+            - name: PODINFO_UI_COLOR
+              value: '#34577c'
+          image: ghcr.io/stefanprodan/podinfo:6.1.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+                - podcli
+                - check
+                - http
+                - localhost:9898/healthz
+            initialDelaySeconds: 1
+            timeoutSeconds: 5
+          name: podinfo
+          ports:
+            - containerPort: 9898
+              name: http
+              protocol: TCP
+            - containerPort: 9797
+              name: http-metrics
+              protocol: TCP
+            - containerPort: 9999
+              name: grpc
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - podcli
+                - check
+                - http
+                - localhost:9898/readyz
+            initialDelaySeconds: 1
+            timeoutSeconds: 5
+          resources:
+            limits: null
+            requests:
+              cpu: 1m
+              memory: 16Mi
+          volumeMounts:
+            - mountPath: /data
+              name: data
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir: {}
+          name: data

--- a/test/helm/helm-remote-chart.test/kude.yaml
+++ b/test/helm/helm-remote-chart.test/kude.yaml
@@ -1,0 +1,20 @@
+apiVersion: kude.kfirs.com/v1alpha1
+kind: Pipeline
+resources:
+  - deployment.yaml
+pipeline:
+  - image: ghcr.io/arikkfir/kude/functions/helm:test
+    network: true
+    config:
+      helm-version: 3.8.1
+      args:
+        - template
+        - helm-remote-chart
+        - podinfo
+        - --create-namespace
+        - --description=Test Helm Remote Chart
+        - --include-crds
+        - --namespace=test
+        - --repo=https://stefanprodan.github.io/podinfo
+        - --skip-tests
+        - --version=6.1.0


### PR DESCRIPTION
This change adds the "helm" generator function, which can execute Helm with arbitrary arguments and pipe its output as YAML resources as the function output.

Naturally, the only use-case here that makes sense is to invoke Helm with the "template" command - as that's the only Helm command that outputs YAML (the others actually install things on the target cluster), but we decided to none-the-less keep this function generic and allow the caller to invoke arbitrary arguments to Helm.

The function will download the appropriate Helm executable based on the given Helm version in the configuration (with a default of 3.8.1). The Helm executable will be cached on the host machine for future invocations.

Closes #33 