### PR TITLE
Allow user to control network access for functions

### DIFF
--- a/internal/docker_function.go
+++ b/internal/docker_function.go
@@ -29,16 +29,17 @@ import (
 var mountKeyRegex = regexp.MustCompile(`^kude\.kfirs\.com/mount:(.+)`)
 
 type dockerFunction struct {
-	pwd         string
-	logger      *logrus.Entry
-	bindsRegexp *regexp.Regexp
-	binds       []string
-	name        string
-	image       string
-	_image      types.ImageSummary
-	entrypoint  []string
-	user        string
-	config      map[string]interface{}
+	pwd          string
+	logger       *logrus.Entry
+	bindsRegexp  *regexp.Regexp
+	binds        []string
+	name         string
+	image        string
+	_image       types.ImageSummary
+	entrypoint   []string
+	user         string
+	allowNetwork bool
+	config       map[string]interface{}
 }
 
 func (f *dockerFunction) pullImage(ctx context.Context, dockerClient *client.Client) error {
@@ -205,7 +206,7 @@ func (f *dockerFunction) createContainer(ctx context.Context, dockerClient *clie
 			},
 			Image:           f.image,
 			Entrypoint:      f.entrypoint,
-			NetworkDisabled: true,
+			NetworkDisabled: !f.allowNetwork,
 			Labels: map[string]string{
 				"kude":        "true",
 				"kudeVersion": pkg.GetVersion().String(),

--- a/internal/pipeline.go
+++ b/internal/pipeline.go
@@ -90,19 +90,24 @@ func BuildPipeline(dir string, writer kio.Writer) (*kio.Pipeline, error) {
 		if !ok {
 			user = ""
 		}
+		allowNetwork, ok := funcConfig["network"].(bool)
+		if !ok {
+			allowNetwork = false
+		}
 		config, ok := funcConfig["config"].(map[string]interface{})
 		if !ok {
 			config = map[string]interface{}{}
 		}
 		filters = append(filters, &dockerFunction{
-			pwd:         pwd,
-			logger:      logrus.WithField("function", name),
-			bindsRegexp: regexp.MustCompile(`mount://([^:]+)(?::([^:]+))?`),
-			name:        name,
-			image:       image,
-			entrypoint:  entrypoint,
-			user:        user,
-			config:      config,
+			pwd:          pwd,
+			logger:       logrus.WithField("function", name),
+			bindsRegexp:  regexp.MustCompile(`mount://([^:]+)(?::([^:]+))?`),
+			name:         name,
+			image:        image,
+			entrypoint:   entrypoint,
+			user:         user,
+			allowNetwork: allowNetwork,
+			config:       config,
 		})
 	}
 	filters = append(filters, &referencesResolverFunction{})


### PR DESCRIPTION
This change allows the user to control whether certain functions are allowed network access or not. Some functions will require network access, but the ultimate decision of whether to allow it must be reserved for the user.

This change allows the user to specify the "network" boolean key under each function, to decide whether that function should receive network access or not (default is to disable network).