### PR TITLE
Remove base64 encoding of ConfigMap values

### DIFF
--- a/cmd/functions/configmap/main.go
+++ b/cmd/functions/configmap/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"crypto/sha1"
-	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"github.com/arikkfir/kude/pkg"
@@ -51,7 +50,7 @@ func main() {
 			}
 			value = string(contents)
 		}
-		data[content.Key] = base64.StdEncoding.EncodeToString([]byte(value))
+		data[content.Key] = value
 		allContent.Write([]byte(value))
 	}
 

--- a/test/configuration/generate-configmap.test/expected.yaml
+++ b/test/configuration/generate-configmap.test/expected.yaml
@@ -56,8 +56,8 @@ spec:
 ---
 apiVersion: v1
 data:
-  foopath: aW1tdXRhYmxlLWJhcg==
-  fooval: aW1tdXRhYmxlLWJhcg==
+  foopath: immutable-bar
+  fooval: immutable-bar
 immutable: true
 kind: ConfigMap
 metadata:
@@ -68,8 +68,8 @@ metadata:
 ---
 apiVersion: v1
 data:
-  foopath: bXV0YWJsZS1iYXI=
-  fooval: bXV0YWJsZS1iYXI=
+  foopath: mutable-bar
+  fooval: mutable-bar
 immutable: false
 kind: ConfigMap
 metadata:
@@ -80,8 +80,8 @@ metadata:
 ---
 apiVersion: v1
 data:
-  foopath: aW1wbGljaXRseS1pbW11dGFibGUtYmFy
-  fooval: aW1wbGljaXRseS1tdXRhYmxlLWJhcg==
+  foopath: implicitly-immutable-bar
+  fooval: implicitly-mutable-bar
 kind: ConfigMap
 metadata:
   annotations:


### PR DESCRIPTION
Current implementation mistakenly base64-encoded ConfigMap values. This should only be done for Secret objects, not ConfigMap objects.

Closes #37 