### PR TITLE
Build & versioning improvements

### DIFF
--- a/.github/workflows/on-push-commit.yml
+++ b/.github/workflows/on-push-commit.yml
@@ -2,11 +2,6 @@ name: Build
 on:
   push:
     branches: [ '*' ]
-    paths-ignore:
-      - .github/workflows/on-push-tag.yml
-      - .github/release*.yml
-      - '**/*.md'
-      - LICENSE
   workflow_dispatch:
 defaults:
   run:
@@ -103,8 +98,8 @@ jobs:
             docker tag ghcr.io/arikkfir/kude/functions/${f}:${{ github.sha }} ghcr.io/arikkfir/kude/functions/${f}:test
           done
         working-directory: cmd/functions
-      - run: go test ./internal/... ./pkg/... -coverprofile=coverage.out # TODO: publish coverage in PR
-      - run: go build -o kude-${{ matrix.os }} cmd/cli/main.go
+      - run: go test ./...
+      - run: go build -o kude-${{ matrix.os }} -ldflags "-X 'github.com/arikkfir/kude/pkg.gitCommit=${{ github.sha }}'" cmd/cli/main.go
         env:
           GOARCH: amd64
           GOOS: ${{ matrix.os }}

--- a/.github/workflows/on-push-tag.yml
+++ b/.github/workflows/on-push-tag.yml
@@ -65,12 +65,14 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: google-github-actions/auth@v0
+      - uses: actions/setup-go@v2
         with:
-          service_account: kude-github-actions@arikkfir.iam.gserviceaccount.com
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-      - uses: google-github-actions/setup-gcloud@v0
-      - run: gsutil cp gs://arikkfir-artifacts/kude/kude-${{ matrix.os }}-${{ github.sha }} ./kude-${{ matrix.os }}
+          go-version: 1.17
+      - run: go mod download
+      - run: go build -o kude-${{ matrix.os }} -ldflags "-X 'github.com/arikkfir/kude/pkg.gitTag=${{ github.ref_name }}' -X 'github.com/arikkfir/kude/pkg.gitCommit=${{ github.sha }}'" cmd/cli/main.go
+        env:
+          GOARCH: amd64
+          GOOS: ${{ matrix.os }}
       - run: gh release upload --clobber ${{ github.ref_name }} ./kude-${{ matrix.os }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"github.com/arikkfir/kude/internal"
+	"github.com/arikkfir/kude/pkg"
 	"github.com/jessevdk/go-flags"
 	"github.com/sirupsen/logrus"
 	"io"
@@ -75,7 +76,10 @@ func main() {
 	ConfigureLogging(cfg.Log.CallerInfo, level)
 
 	// Configured!
-	logrus.WithField("config", fmt.Sprintf("%+v", &cfg)).Debug("Configured")
+	logrus.
+		WithField("version", "v"+pkg.GetVersion().String()).
+		WithField("config", fmt.Sprintf("%+v", &cfg)).
+		Debug("Configured")
 
 	// Read pipeline
 	pwd, err := os.Getwd()

--- a/cmd/functions/annotate/Dockerfile
+++ b/cmd/functions/annotate/Dockerfile
@@ -30,5 +30,5 @@ ENV GOTRACEBACK=all
 ENTRYPOINT ["/function"]
 
 ### Labels
-LABEL "kude.kfirs.com/minimum-version"=0.0.0
+LABEL "kude.kfirs.com/minimum-version"="0.0.0-dev"
 LABEL "kude.kfirs.com/mount:1"="$.path"

--- a/cmd/functions/configmap/Dockerfile
+++ b/cmd/functions/configmap/Dockerfile
@@ -30,5 +30,5 @@ ENV GOTRACEBACK=all
 ENTRYPOINT ["/function"]
 
 ### Labels
-LABEL "kude.kfirs.com/minimum-version"=0.0.0
+LABEL "kude.kfirs.com/minimum-version"="0.0.0-dev"
 LABEL "kude.kfirs.com/mount:1"="$.contents[*].path"

--- a/cmd/functions/helm/Dockerfile
+++ b/cmd/functions/helm/Dockerfile
@@ -30,5 +30,5 @@ ENV GOTRACEBACK=all
 ENTRYPOINT ["/function"]
 
 ### Labels
-LABEL "kude.kfirs.com/minimum-version"=0.0.0
+LABEL "kude.kfirs.com/minimum-version"="0.0.0-dev"
 LABEL "kude.kfirs.com/mount:1"="$.path"

--- a/cmd/functions/label/Dockerfile
+++ b/cmd/functions/label/Dockerfile
@@ -30,5 +30,5 @@ ENV GOTRACEBACK=all
 ENTRYPOINT ["/function"]
 
 ### Labels
-LABEL "kude.kfirs.com/minimum-version"=0.0.0
+LABEL "kude.kfirs.com/minimum-version"="0.0.0-dev"
 LABEL "kude.kfirs.com/mount:1"="$.path"

--- a/cmd/functions/secret/Dockerfile
+++ b/cmd/functions/secret/Dockerfile
@@ -30,5 +30,5 @@ ENV GOTRACEBACK=all
 ENTRYPOINT ["/function"]
 
 ### Labels
-LABEL "kude.kfirs.com/minimum-version"=0.0.0
+LABEL "kude.kfirs.com/minimum-version"="0.0.0-dev"
 LABEL "kude.kfirs.com/mount:1"="$.contents[*].path"

--- a/internal/pipeline.go
+++ b/internal/pipeline.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"github.com/arikkfir/kude/pkg"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"io"
@@ -10,6 +11,8 @@ import (
 	"regexp"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
+	"strconv"
+	"strings"
 )
 
 const (
@@ -81,6 +84,8 @@ func BuildPipeline(dir string, writer kio.Writer) (*kio.Pipeline, error) {
 		image, ok := funcConfig["image"].(string)
 		if !ok {
 			return nil, fmt.Errorf("failed to get image for function '%s': %w", name, err)
+		} else if !strings.Contains(image, ":") {
+			image = image + ":v" + strconv.FormatUint(pkg.GetVersion().Major, 10)
 		}
 		entrypoint, ok := funcConfig["entrypoint"].([]string)
 		if !ok {

--- a/internal/pipeline_test.go
+++ b/internal/pipeline_test.go
@@ -17,6 +17,34 @@ import (
 	"testing"
 )
 
+func TestBuildPipelineInfersFunctionVersion(t *testing.T) {
+	absPath, err := filepath.Abs("../test/pipeline/inferred-function-version")
+	if err != nil {
+		t.Error(err)
+	}
+	pipeline, err := BuildPipeline(absPath, &kio.ByteWriter{Writer: &bytes.Buffer{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	df := pipeline.Filters[0].(*dockerFunction)
+	if df.image != "ghcr.io/arikkfir/kude/functions/annotate:v0" {
+		t.Errorf("expected image to be ghcr.io/arikkfir/kude/functions/annotate:v0, got %s", df.image)
+	}
+
+	absPath, err = filepath.Abs("../test/pipeline/single-function.test")
+	if err != nil {
+		t.Error(err)
+	}
+	pipeline, err = BuildPipeline(absPath, &kio.ByteWriter{Writer: &bytes.Buffer{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	df = pipeline.Filters[0].(*dockerFunction)
+	if df.image != "ghcr.io/arikkfir/kude/functions/annotate:test" {
+		t.Errorf("expected image to be ghcr.io/arikkfir/kude/functions/annotate:test, got %s", df.image)
+	}
+}
+
 func TestDeployments(t *testing.T) {
 	root := "../test"
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -2,10 +2,18 @@ package pkg
 
 import "github.com/blang/semver"
 
-// TODO: inject version externally (checkout https://blog.alexellis.io/inject-build-time-vars-golang/)
+var gitCommit = "unknown"
+var gitTag = "0.0.0-dev"
+var version semver.Version
 
-var kudeVersion = semver.MustParse("0.0.1")
+func init() {
+	if gitTag[0] == 'v' {
+		gitTag = gitTag[1:]
+	}
+	version = semver.MustParse(gitTag + "+" + gitCommit)
+}
 
+// GetVersion returns the kude version currently running.
 func GetVersion() semver.Version {
-	return kudeVersion
+	return version
 }

--- a/test/pipeline/inferred-function-version/kude.yaml
+++ b/test/pipeline/inferred-function-version/kude.yaml
@@ -1,0 +1,7 @@
+apiVersion: kude.kfirs.com/v1alpha1
+kind: Pipeline
+pipeline:
+  - image: ghcr.io/arikkfir/kude/functions/annotate
+    config:
+      name: foo
+      value: bar


### PR DESCRIPTION
This change injects Git commit SHA and tag into the executable, allowing Kude to be aware of its version. 

That enables defaulting the version of functions when those are not specified.