### PR TITLE
Remove test parallelization for pipeline tests

### DIFF
--- a/internal/pipeline_test.go
+++ b/internal/pipeline_test.go
@@ -63,7 +63,19 @@ func TestDeployments(t *testing.T) {
 				t.Error(err)
 			}
 			t.Run("PATH="+path, func(t *testing.T) {
-				t.Parallel()
+				pwd, err := os.Getwd()
+				if err != nil {
+					t.Error(err)
+				}
+				if err := os.Chdir(absPath); err != nil {
+					t.Fatal(err)
+				}
+				defer func() {
+					err := os.Chdir(pwd)
+					if err != nil {
+						t.Error(err)
+					}
+				}()
 
 				actual := bytes.Buffer{}
 				pipeline, err := BuildPipeline(absPath, &kio.ByteWriter{Writer: &actual})


### PR DESCRIPTION
Parallelization won't work for pipeline tests, as it relies on working
directory, which is global for the process.