### PR TITLE
Fix CI tag build

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,14 +1,23 @@
-name: Build
+name: Build PR
+
 on:
-  push:
-    branches: [ '*' ]
-  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/build.yml
+    types:
+      - synchronize
+      - opened
+      - reopened
+
 defaults:
   run:
     shell: bash -eu {0}
+
 env:
   GO_VERSION: "1.18"
+
 jobs:
+
   discover-functions:
     outputs:
       functions: ${{ steps.discover.outputs.functions }}
@@ -18,24 +27,31 @@ jobs:
       - id: discover
         run: echo "::set-output name=functions::$(ls -d * | jq -R -s -c 'split("\n")[:-1]')"
         working-directory: cmd/functions
+
   build-functions:
-    name: Build function ${{ matrix.function }}
-    needs: [ discover-functions ]
+    name: "Build function: ${{ matrix.function }}"
+    needs: discover-functions
     permissions:
       contents: read
       packages: write
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        function: ${{fromJson(needs.discover-functions.outputs.functions)}}
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
         id: buildx
         with:
           install: true
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-multi-buildx-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-multi-buildx-
+          key: buildx-${{ runner.os }}-${{ matrix.function }}-${{ github.sha }}
+          restore-keys: |
+            buildx-${{ runner.os }}-${{ matrix.function }}-
+            buildx-${{ runner.os }}-
+            buildx-
       - uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -63,12 +79,10 @@ jobs:
           push: true
           tags: ${{ steps.docker-meta.outputs.tags }}
       - run: rm -rf /tmp/.buildx-cache && mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-    strategy:
-      matrix:
-        function: ${{fromJson(needs.discover-functions.outputs.functions)}}
+
   build-cli-linux:
     name: Build Linux CLI
-    needs: [ build-functions ]
+    needs: build-functions
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -80,8 +94,10 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          key: golang-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            golang-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
+            golang-${{ runner.os }}-
       - run: go mod download
       - run: go vet ./...
       - run: go test -ldflags "-X 'github.com/arikkfir/kude/pkg.gitCommit=${{ github.sha }}'" ./...
@@ -95,9 +111,10 @@ jobs:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
       - uses: google-github-actions/setup-gcloud@v0
       - run: gsutil cp kude-linux-amd64 gs://arikkfir-artifacts/kude/kude-linux-amd64-${{ github.sha }}
+
   build-cli-darwin:
     name: Build Darwin CLI
-    needs: [ build-functions, build-cli-linux ]
+    needs: build-functions
     runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
@@ -109,8 +126,10 @@ jobs:
           path: |
             ~/Library/Caches/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          key: golang-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            golang-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
+            golang-${{ runner.os }}-
       - run: go mod download
       - run: go vet ./...
       - run: go build -o kude-darwin-amd64 -ldflags "-X 'github.com/arikkfir/kude/pkg.gitCommit=${{ github.sha }}'" cmd/cli/main.go

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -2,8 +2,6 @@ name: Build PR
 
 on:
   pull_request:
-    paths:
-      - .github/workflows/build.yml
     types:
       - synchronize
       - opened

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -1,22 +1,19 @@
-name: Tag
+name: Build Tag
+
 on:
-  push:
-    tags: [ v* ]
+  release:
+    types:
+      - published
+
 defaults:
   run:
     shell: bash -eu {0}
-# TODO: detect if most recent release and tag as latest
+
 env:
   GO_VERSION: "1.18"
+
 jobs:
-  release:
-    name: Create Release
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - run: gh release create --draft --generate-notes ${{ github.ref_name }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   discover-functions:
     outputs:
       functions: ${{ steps.discover.outputs.functions }}
@@ -26,13 +23,17 @@ jobs:
       - id: discover
         run: echo "::set-output name=functions::$(ls -d * | jq -R -s -c 'split("\n")[:-1]')"
         working-directory: cmd/functions
+
   tag-functions:
-    name: Tag function ${{ matrix.function }}
-    needs: [ discover-functions ]
+    name: "Tag function: ${{ matrix.function }}"
+    needs: discover-functions
     permissions:
       contents: read
       packages: write
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        function: ${{fromJson(needs.discover-functions.outputs.functions)}}
     steps:
       - uses: docker/login-action@v1
         with:
@@ -58,12 +59,10 @@ jobs:
           done
         env:
           IMAGE: ghcr.io/arikkfir/kude/functions/${{ matrix.function }}:${{ github.sha }}
-    strategy:
-      matrix:
-        function: ${{fromJson(needs.discover-functions.outputs.functions)}}
+
   build-linux-cli:
     name: Tag Linux CLI
-    needs: [ release ]
+    needs: tag-functions
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -75,9 +74,13 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          key: golang-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            golang-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
+            golang-${{ runner.os }}-
       - run: go mod download
+      - run: go vet ./...
+      - run: go test -ldflags "-X 'github.com/arikkfir/kude/pkg.gitTag=${{ github.ref_name }}' -X 'github.com/arikkfir/kude/pkg.gitCommit=${{ github.sha }}'" ./...
       - run: go build -o kude-linux-amd64 -ldflags "-X 'github.com/arikkfir/kude/pkg.gitTag=${{ github.ref_name }}' -X 'github.com/arikkfir/kude/pkg.gitCommit=${{ github.sha }}'" cmd/cli/main.go
         env:
           GOARCH: amd64
@@ -85,9 +88,10 @@ jobs:
       - run: gh release upload --clobber ${{ github.ref_name }} ./kude-linux-amd64
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build-darwin-cli:
     name: Tag Darwin CLI
-    needs: [ release ]
+    needs: tag-functions
     runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
@@ -99,9 +103,13 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          key: golang-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            golang-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
+            golang-${{ runner.os }}-
       - run: go mod download
+      - run: go vet ./...
+      - run: go test -ldflags "-X 'github.com/arikkfir/kude/pkg.gitTag=${{ github.ref_name }}' -X 'github.com/arikkfir/kude/pkg.gitCommit=${{ github.sha }}'" ./...
       - run: go build -o kude-darwin-amd64 -ldflags "-X 'github.com/arikkfir/kude/pkg.gitTag=${{ github.ref_name }}' -X 'github.com/arikkfir/kude/pkg.gitCommit=${{ github.sha }}'" cmd/cli/main.go
         env:
           GOARCH: amd64

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -24,8 +24,8 @@ jobs:
         run: echo "::set-output name=functions::$(ls -d * | jq -R -s -c 'split("\n")[:-1]')"
         working-directory: cmd/functions
 
-  tag-functions:
-    name: "Tag function: ${{ matrix.function }}"
+  build-functions:
+    name: "Build function: ${{ matrix.function }}"
     needs: discover-functions
     permissions:
       contents: read
@@ -35,6 +35,19 @@ jobs:
       matrix:
         function: ${{fromJson(needs.discover-functions.outputs.functions)}}
     steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
+        id: buildx
+        with:
+          install: true
+      - uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: buildx-${{ runner.os }}-${{ matrix.function }}-${{ github.sha }}
+          restore-keys: |
+            buildx-${{ runner.os }}-${{ matrix.function }}-
+            buildx-${{ runner.os }}-
+            buildx-
       - uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -50,19 +63,24 @@ jobs:
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
             type=ref,event=tag
-      - run: |-
-          docker pull ${IMAGE}
-          TAGS="${{ steps.docker-meta.outputs.tags }}"
-          for tag in ${TAGS}; do
-            docker tag ${IMAGE} ${tag}
-            docker push ${tag}
-          done
-        env:
-          IMAGE: ghcr.io/arikkfir/kude/functions/${{ matrix.function }}:${{ github.sha }}
+            type=ref,event=branch
+            type=sha,prefix=,format=short
+            type=sha,prefix=,format=long
+      - uses: docker/build-push-action@v2
+        with:
+          build-args: function=${{ matrix.function }}
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+          file: cmd/functions/${{ matrix.function }}/Dockerfile
+          labels: ${{ steps.docker-meta.outputs.labels }}
+          push: true
+          tags: ${{ steps.docker-meta.outputs.tags }}
+      - run: rm -rf /tmp/.buildx-cache && mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  build-linux-cli:
-    name: Tag Linux CLI
-    needs: tag-functions
+  build-cli-linux:
+    name: Build Linux CLI
+    needs: build-functions
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -89,9 +107,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  build-darwin-cli:
-    name: Tag Darwin CLI
-    needs: tag-functions
+  build-cli-darwin:
+    name: Build Darwin CLI
+    needs: build-functions
     runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
@@ -101,7 +119,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: |
-            ~/.cache/go-build
+            ~/Library/Caches/go-build
             ~/go/pkg/mod
           key: golang-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
           restore-keys: |
@@ -109,7 +127,6 @@ jobs:
             golang-${{ runner.os }}-
       - run: go mod download
       - run: go vet ./...
-      - run: go test -ldflags "-X 'github.com/arikkfir/kude/pkg.gitTag=${{ github.ref_name }}' -X 'github.com/arikkfir/kude/pkg.gitCommit=${{ github.sha }}'" ./...
       - run: go build -o kude-darwin-amd64 -ldflags "-X 'github.com/arikkfir/kude/pkg.gitTag=${{ github.ref_name }}' -X 'github.com/arikkfir/kude/pkg.gitCommit=${{ github.sha }}'" cmd/cli/main.go
         env:
           GOARCH: amd64


### PR DESCRIPTION
Building a tag can no longer rely on the fact that the tag's commit SHA has been built before. That is because only PRs are built.