### PR TITLE
Build improvements

### DIFF
--- a/.github/workflows/build-commits.yml
+++ b/.github/workflows/build-commits.yml
@@ -1,6 +1,9 @@
-name: Build PR
+name: Build Commit
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types:
       - synchronize
@@ -61,7 +64,6 @@ jobs:
           images: ghcr.io/arikkfir/kude/functions/${{ matrix.function }}
           tags: |
             type=ref,event=branch
-            type=ref,event=tag
             type=ref,event=pr
             type=sha,prefix=,format=short
             type=sha,prefix=,format=long
@@ -78,8 +80,8 @@ jobs:
           tags: ${{ steps.docker-meta.outputs.tags }}
       - run: rm -rf /tmp/.buildx-cache && mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-  build-cli-linux:
-    name: Build Linux CLI
+  verify:
+    name: Verify
     needs: build-functions
     runs-on: ubuntu-20.04
     steps:
@@ -99,64 +101,3 @@ jobs:
       - run: go mod download
       - run: go vet ./...
       - run: go test -ldflags "-X 'github.com/arikkfir/kude/pkg.gitCommit=${{ github.sha }}'" ./...
-      - run: go build -o kude-linux-amd64 -ldflags "-X 'github.com/arikkfir/kude/pkg.gitCommit=${{ github.sha }}'" cmd/cli/main.go
-        env:
-          GOARCH: amd64
-          GOOS: linux
-      - uses: google-github-actions/auth@v0
-        with:
-          service_account: gha-arikkfir-kude@arikkfir.iam.gserviceaccount.com
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-      - uses: google-github-actions/setup-gcloud@v0
-      - run: gsutil cp kude-linux-amd64 gs://arikkfir-artifacts/kude/kude-linux-amd64-${{ github.sha }}
-
-  build-cli-darwin:
-    name: Build Darwin CLI
-    needs: build-functions
-    runs-on: macos-11
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GO_VERSION }}
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/Library/Caches/go-build
-            ~/go/pkg/mod
-          key: golang-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
-          restore-keys: |
-            golang-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
-            golang-${{ runner.os }}-
-      - run: go mod download
-      - run: go vet ./...
-      - run: go build -o kude-darwin-amd64 -ldflags "-X 'github.com/arikkfir/kude/pkg.gitCommit=${{ github.sha }}'" cmd/cli/main.go
-        env:
-          GOARCH: amd64
-          GOOS: darwin
-      - env:
-          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
-        run: |
-          echo -n "${MACOS_CERTIFICATE}" | base64 --decode > certificate.p12
-          echo -n "${MACOS_CERTIFICATE_PWD}" > certificate.pwd
-          set -x
-          security create-keychain -p macos123 build.keychain
-          security default-keychain -s build.keychain
-          security unlock-keychain -p macos123 build.keychain
-          security import certificate.p12 -k build.keychain -P "$(cat certificate.pwd)" -T /usr/bin/codesign
-          security find-identity -v build.keychain
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k macos123 build.keychain
-          /usr/bin/codesign \
-                  --force \
-                  --keychain build.keychain \
-                  --sign "Developer ID Application: Arye Kfir (9ARDRAN4L7)" \
-                  --identifier "com.kfirs.kude" \
-                  --verbose \
-                  kude-darwin-amd64
-      - uses: google-github-actions/auth@v0
-        with:
-          service_account: gha-arikkfir-kude@arikkfir.iam.gserviceaccount.com
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-      - uses: google-github-actions/setup-gcloud@v0
-      - run: gsutil cp kude-darwin-amd64 gs://arikkfir-artifacts/kude/kude-darwin-amd64-${{ github.sha }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,4 +1,4 @@
-name: Build Tag
+name: Build Release
 
 on:
   release:
@@ -35,19 +35,9 @@ jobs:
       matrix:
         function: ${{fromJson(needs.discover-functions.outputs.functions)}}
     steps:
-      - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
-        id: buildx
         with:
           install: true
-      - uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: buildx-${{ runner.os }}-${{ matrix.function }}-${{ github.sha }}
-          restore-keys: |
-            buildx-${{ runner.os }}-${{ matrix.function }}-
-            buildx-${{ runner.os }}-
-            buildx-
       - uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -63,19 +53,15 @@ jobs:
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
             type=ref,event=tag
-            type=sha,prefix=,format=short
-            type=sha,prefix=,format=long
-      - uses: docker/build-push-action@v2
-        with:
-          build-args: function=${{ matrix.function }}
-          builder: ${{ steps.buildx.outputs.name }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
-          file: cmd/functions/${{ matrix.function }}/Dockerfile
-          labels: ${{ steps.docker-meta.outputs.labels }}
-          push: true
-          tags: ${{ steps.docker-meta.outputs.tags }}
-      - run: rm -rf /tmp/.buildx-cache && mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      - run: |-
+          docker pull ${IMAGE}
+          TAGS="${{ steps.docker-meta.outputs.tags }}"
+          for tag in ${TAGS}; do
+            docker tag ${IMAGE} ${tag}
+            docker push ${tag}
+          done
+        env:
+          IMAGE: ghcr.io/arikkfir/kude/functions/${{ matrix.function }}:${{ github.sha }}
 
   build-cli-linux:
     name: Build Linux CLI
@@ -96,8 +82,6 @@ jobs:
             golang-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
             golang-${{ runner.os }}-
       - run: go mod download
-      - run: go vet ./...
-      - run: go test -ldflags "-X 'github.com/arikkfir/kude/pkg.gitTag=${{ github.ref_name }}' -X 'github.com/arikkfir/kude/pkg.gitCommit=${{ github.sha }}'" ./...
       - run: go build -o kude-linux-amd64 -ldflags "-X 'github.com/arikkfir/kude/pkg.gitTag=${{ github.ref_name }}' -X 'github.com/arikkfir/kude/pkg.gitCommit=${{ github.sha }}'" cmd/cli/main.go
         env:
           GOARCH: amd64
@@ -125,7 +109,6 @@ jobs:
             golang-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
             golang-${{ runner.os }}-
       - run: go mod download
-      - run: go vet ./...
       - run: go build -o kude-darwin-amd64 -ldflags "-X 'github.com/arikkfir/kude/pkg.gitTag=${{ github.ref_name }}' -X 'github.com/arikkfir/kude/pkg.gitCommit=${{ github.sha }}'" cmd/cli/main.go
         env:
           GOARCH: amd64


### PR DESCRIPTION
- Build the "main" branch as well
- Builds of branches (including "main") should not generate CLI
  executables, as they have little value
- Since "main" branch is now built too, Release builds can simply tag
  function Docker images with additional tags, instead of rebuilding
  them
- Release builds no longer need to vet & test the CLI executable builds

All the changes above should also yield a significant performance
improvement for the CI workflows.