### PR TITLE
Print stderr from pipeline in tests

### DIFF
--- a/cmd/functions/annotate/scenario_test.go
+++ b/cmd/functions/annotate/scenario_test.go
@@ -41,6 +41,10 @@ func TestAnnotate(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {

--- a/cmd/functions/create-configmap/scenario_test.go
+++ b/cmd/functions/create-configmap/scenario_test.go
@@ -41,6 +41,10 @@ func TestCreateConfigmap(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {

--- a/cmd/functions/create-namespace/scenario_test.go
+++ b/cmd/functions/create-namespace/scenario_test.go
@@ -41,6 +41,10 @@ func TestCreateNamespace(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {

--- a/cmd/functions/create-secret/scenario_test.go
+++ b/cmd/functions/create-secret/scenario_test.go
@@ -41,6 +41,10 @@ func TestCreateSecret(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {

--- a/cmd/functions/helm/render-chart-with-local-values-file/scenario_test.go
+++ b/cmd/functions/helm/render-chart-with-local-values-file/scenario_test.go
@@ -41,6 +41,10 @@ func TestRenderChartWithLocalValuesFile(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {

--- a/cmd/functions/helm/render-remote-chart-without-local-resources/scenario_test.go
+++ b/cmd/functions/helm/render-remote-chart-without-local-resources/scenario_test.go
@@ -41,6 +41,10 @@ func TestRenderRemoteChartWithoutLocalResources(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {

--- a/cmd/functions/helm/render-remote-helm-chart/scenario_test.go
+++ b/cmd/functions/helm/render-remote-helm-chart/scenario_test.go
@@ -41,6 +41,10 @@ func TestRenderRemoteHelmChart(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {

--- a/cmd/functions/set-namespace/scenario_test.go
+++ b/cmd/functions/set-namespace/scenario_test.go
@@ -41,6 +41,10 @@ func TestSetNamespace(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {

--- a/cmd/functions/yq/scenario_test.go
+++ b/cmd/functions/yq/scenario_test.go
@@ -41,6 +41,10 @@ func TestYq(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {

--- a/test/generate/test-template.go.tmpl
+++ b/test/generate/test-template.go.tmpl
@@ -41,6 +41,10 @@ func Test{{ .ScenarioName }}(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {

--- a/test/scenarios/empty-pipeline/scenario_test.go
+++ b/test/scenarios/empty-pipeline/scenario_test.go
@@ -41,6 +41,10 @@ func TestEmptyPipeline(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {

--- a/test/scenarios/formatting-no-function/scenario_test.go
+++ b/test/scenarios/formatting-no-function/scenario_test.go
@@ -41,6 +41,10 @@ func TestFormattingNoFunction(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {

--- a/test/scenarios/formatting-with-function/scenario_test.go
+++ b/test/scenarios/formatting-with-function/scenario_test.go
@@ -41,6 +41,10 @@ func TestFormattingWithFunction(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {

--- a/test/scenarios/import-external-file/scenario_test.go
+++ b/test/scenarios/import-external-file/scenario_test.go
@@ -41,6 +41,10 @@ func TestImportExternalFile(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {

--- a/test/scenarios/import-external-kude-pkg/scenario_test.go
+++ b/test/scenarios/import-external-kude-pkg/scenario_test.go
@@ -41,6 +41,10 @@ func TestImportExternalKudePkg(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {

--- a/test/scenarios/import-multiple-local-files/scenario_test.go
+++ b/test/scenarios/import-multiple-local-files/scenario_test.go
@@ -41,6 +41,10 @@ func TestImportMultipleLocalFiles(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {

--- a/test/scenarios/import-nested-subdir/scenario_test.go
+++ b/test/scenarios/import-nested-subdir/scenario_test.go
@@ -41,6 +41,10 @@ func TestImportNestedSubdir(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {

--- a/test/scenarios/import-remote-github-files/scenario_test.go
+++ b/test/scenarios/import-remote-github-files/scenario_test.go
@@ -41,6 +41,10 @@ func TestImportRemoteGithubFiles(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {

--- a/test/scenarios/import-remote-github-kude-pkg/scenario_test.go
+++ b/test/scenarios/import-remote-github-kude-pkg/scenario_test.go
@@ -41,6 +41,10 @@ func TestImportRemoteGithubKudePkg(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {

--- a/test/scenarios/import-remote-github-nested-path/scenario_test.go
+++ b/test/scenarios/import-remote-github-nested-path/scenario_test.go
@@ -41,6 +41,10 @@ func TestImportRemoteGithubNestedPath(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {

--- a/test/scenarios/invoke-multiple-different-functions/scenario_test.go
+++ b/test/scenarios/invoke-multiple-different-functions/scenario_test.go
@@ -41,6 +41,10 @@ func TestInvokeMultipleDifferentFunctions(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {

--- a/test/scenarios/invoke-single-function/scenario_test.go
+++ b/test/scenarios/invoke-single-function/scenario_test.go
@@ -41,6 +41,10 @@ func TestInvokeSingleFunction(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {

--- a/test/scenarios/referenced-objects/scenario_test.go
+++ b/test/scenarios/referenced-objects/scenario_test.go
@@ -41,6 +41,10 @@ func TestReferencedObjects(t *testing.T) {
 		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
 	}
 	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
 
 	formattedYAML, err := test.FormatYAML(stdout)
 	if err != nil {


### PR DESCRIPTION
Tests should print their pipeline's stderr to help debug issues.