### PR TITLE
Support label selectors for some functions

### DIFF
--- a/cmd/functions/annotate/expected.yaml
+++ b/cmd/functions/annotate/expected.yaml
@@ -5,4 +5,16 @@ metadata:
     fromFile: stored in a file
     numeric: "123"
     string: abc
-  name: annotated
+  name: svc1
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    fromFile: stored in a file
+    numeric: "123"
+    special: "yes"
+    string: abc
+  labels:
+    labeled: "yes"
+  name: svc2

--- a/cmd/functions/annotate/kude.yaml
+++ b/cmd/functions/annotate/kude.yaml
@@ -17,3 +17,8 @@ pipeline:
     config:
       name: string
       value: "abc"
+  - image: ghcr.io/arikkfir/kude/functions/annotate
+    config:
+      label-selector: labeled=yes
+      name: special
+      value: "yes"

--- a/cmd/functions/annotate/resources.yaml
+++ b/cmd/functions/annotate/resources.yaml
@@ -1,4 +1,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: annotated
+  name: svc1
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    labeled: "yes"
+  name: svc2

--- a/cmd/functions/label/expected.yaml
+++ b/cmd/functions/label/expected.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    fromFile: stored in a file
+    numeric: "123"
+    string: abc
+  name: labeled

--- a/cmd/functions/label/kude.yaml
+++ b/cmd/functions/label/kude.yaml
@@ -1,0 +1,19 @@
+apiVersion: kude.kfirs.com/v1alpha1
+kind: Pipeline
+resources:
+  - resources.yaml
+pipeline:
+  - image: ghcr.io/arikkfir/kude/functions/label
+    config:
+      name: fromFile
+      path: value.txt
+    mounts:
+      - value.txt
+  - image: ghcr.io/arikkfir/kude/functions/label
+    config:
+      name: numeric
+      value: "123"
+  - image: ghcr.io/arikkfir/kude/functions/label
+    config:
+      name: string
+      value: "abc"

--- a/cmd/functions/label/resources.yaml
+++ b/cmd/functions/label/resources.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: labeled

--- a/cmd/functions/label/scenario_test.go
+++ b/cmd/functions/label/scenario_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"github.com/arikkfir/kude/internal"
+	"github.com/arikkfir/kude/test"
+	"github.com/hexops/gotextdiff"
+	"github.com/hexops/gotextdiff/myers"
+	"github.com/hexops/gotextdiff/span"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"testing"
+)
+
+const failureMessage = `%s: %w
+STDERR:
+=======
+%s
+-------
+STDOUT:
+=======
+%s
+-------`
+
+func TestLabel(t *testing.T) {
+	pwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(fmt.Errorf("error getting working directory: %w", err))
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	if pipeline, err := internal.NewPipeline(log.New(stderr, "", 0), pwd, kio.ByteWriter{Writer: stdout}); err != nil {
+		t.Fatal(fmt.Errorf(failureMessage, "failed to build pipeline", err, stderr, stdout))
+	} else if err := pipeline.Execute(); err != nil {
+		t.Fatal(fmt.Errorf(failureMessage, "failed to execute pipeline", err, stderr, stdout))
+	}
+	defer os.RemoveAll(filepath.Join(pwd, ".kude"))
+	t.Logf(`Pipeline stderr output:
+======
+%s
+======`, stderr.String())
+
+	formattedYAML, err := test.FormatYAML(stdout)
+	if err != nil {
+		t.Fatal(fmt.Errorf(failureMessage, "failed to format YAML output", err, stderr, stdout))
+	}
+
+	expectedPath := filepath.Join(pwd, "expected.yaml")
+	expectedFile, err := os.Open(expectedPath)
+	if err != nil {
+		t.Fatal(fmt.Errorf("failed opening expected YAML file at '%s': %w", expectedPath, err))
+	}
+	expected, err := io.ReadAll(expectedFile)
+	if err != nil {
+		t.Fatal(fmt.Errorf("failed reading expected YAML file at '%s': %w", expectedPath, err))
+	}
+	if string(expected) != formattedYAML {
+		edits := myers.ComputeEdits(span.URIFromPath("expected"), string(expected), formattedYAML)
+		diff := fmt.Sprint(gotextdiff.ToUnified("expected", "actual", string(expected), edits))
+		t.Errorf("Incorrect output:\n===\n%s\n===", diff)
+	}
+}

--- a/cmd/functions/label/value.txt
+++ b/cmd/functions/label/value.txt
@@ -1,0 +1,1 @@
+stored in a file

--- a/cmd/functions/set-namespace/main.go
+++ b/cmd/functions/set-namespace/main.go
@@ -17,9 +17,18 @@ func main() {
 		panic(fmt.Errorf("namespace is required"))
 	}
 
+	labelSelector := viper.GetString("label-selector")
+
 	pipeline := kio.Pipeline{
-		Inputs:  []kio.Reader{&kio.ByteReader{Reader: os.Stdin}},
-		Filters: []kio.Filter{pkg.Fanout(yaml.SetK8sNamespace(namespace))},
+		Inputs: []kio.Reader{&kio.ByteReader{Reader: os.Stdin}},
+		Filters: []kio.Filter{
+			pkg.Fanout(
+				yaml.Tee(
+					pkg.SingleResourceLabelSelector(labelSelector),
+					yaml.SetK8sNamespace(namespace),
+				),
+			),
+		},
 		Outputs: []kio.Writer{kio.ByteWriter{Writer: os.Stdout}},
 	}
 	if err := pipeline.Execute(); err != nil {

--- a/pkg/kyaml_fanout.go
+++ b/pkg/kyaml_fanout.go
@@ -1,7 +1,6 @@
 package pkg
 
 import (
-	"fmt"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
@@ -23,23 +22,4 @@ func (s pipelineFanout) Filter(resources []*yaml.RNode) ([]*yaml.RNode, error) {
 
 func Fanout(processor yaml.Filter) kio.Filter {
 	return pipelineFanout{processor: processor}
-}
-
-type generator struct {
-	generator GeneratorFunc
-}
-
-type GeneratorFunc func() ([]*yaml.RNode, error)
-
-func (g generator) Filter(resources []*yaml.RNode) ([]*yaml.RNode, error) {
-	generated, err := g.generator()
-	if err != nil {
-		return nil, fmt.Errorf("failed generating nodes: %w", err)
-	}
-	resources = append(resources, generated...)
-	return resources, nil
-}
-
-func Generate(generatorFunc GeneratorFunc) kio.Filter {
-	return generator{generator: generatorFunc}
 }

--- a/pkg/kyaml_generator.go
+++ b/pkg/kyaml_generator.go
@@ -1,0 +1,26 @@
+package pkg
+
+import (
+	"fmt"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+type generator struct {
+	generator GeneratorFunc
+}
+
+type GeneratorFunc func() ([]*yaml.RNode, error)
+
+func (g generator) Filter(resources []*yaml.RNode) ([]*yaml.RNode, error) {
+	generated, err := g.generator()
+	if err != nil {
+		return nil, fmt.Errorf("failed generating nodes: %w", err)
+	}
+	resources = append(resources, generated...)
+	return resources, nil
+}
+
+func Generate(generatorFunc GeneratorFunc) kio.Filter {
+	return generator{generator: generatorFunc}
+}

--- a/pkg/kyaml_labelselector.go
+++ b/pkg/kyaml_labelselector.go
@@ -1,0 +1,45 @@
+package pkg
+
+import (
+	"fmt"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+type singleResourceLabelSelector struct {
+	selector string
+}
+
+func (s singleResourceLabelSelector) Filter(resource *yaml.RNode) (*yaml.RNode, error) {
+	if matches, err := resource.MatchesLabelSelector(s.selector); err != nil {
+		return nil, fmt.Errorf("resource '%s/%s' failed matching labels selector '%s': %w", resource.GetNamespace(), resource.GetName(), s.selector, err)
+	} else if matches {
+		return resource, nil
+	} else {
+		return nil, nil
+	}
+}
+
+func SingleResourceLabelSelector(selector string) yaml.Filter {
+	return singleResourceLabelSelector{selector}
+}
+
+type multiResourceLabelSelector struct {
+	selector string
+}
+
+func (s multiResourceLabelSelector) Filter(resources []*yaml.RNode) ([]*yaml.RNode, error) {
+	result := make([]*yaml.RNode, 0)
+	for _, resource := range resources {
+		if matches, err := resource.MatchesLabelSelector(s.selector); err != nil {
+			return nil, fmt.Errorf("resource '%s/%s' failed matching labels selector '%s': %w", resource.GetNamespace(), resource.GetName(), s.selector, err)
+		} else if matches {
+			result = append(result, resource)
+		}
+	}
+	return result, nil
+}
+
+func MultiResourceLabelSelector(selector string) kio.Filter {
+	return multiResourceLabelSelector{selector}
+}


### PR DESCRIPTION
This change adds support for annotating, labeling or setting-namespace only for a subset of the resources, by specifying a label selector; this means that the relevant function will only update resources matching the given labels.