### PR TITLE
Refactor label selector mechanism

### DIFF
--- a/cmd/functions/annotate/kude.yaml
+++ b/cmd/functions/annotate/kude.yaml
@@ -19,6 +19,8 @@ pipeline:
       value: "abc"
   - image: ghcr.io/arikkfir/kude/functions/annotate
     config:
-      label-selector: labeled=yes
       name: special
       value: "yes"
+      targets:
+        includes:
+          - labelSelector: labeled=yes

--- a/cmd/functions/annotate/main.go
+++ b/cmd/functions/annotate/main.go
@@ -28,14 +28,21 @@ func main() {
 		value = viper.GetString("value")
 	}
 
-	labelSelector := viper.GetString("label-selector")
+	includes := make([]pkg.TargetingFilter, 0)
+	if err := viper.UnmarshalKey("targets.includes", &includes); err != nil {
+		panic(fmt.Errorf("failed to unmarshal targeting includes: %w", err))
+	}
+	excludes := make([]pkg.TargetingFilter, 0)
+	if err := viper.UnmarshalKey("targets.excludes", &excludes); err != nil {
+		panic(fmt.Errorf("failed to unmarshal targeting excludes: %w", err))
+	}
 
 	pipeline := kio.Pipeline{
 		Inputs: []kio.Reader{&kio.ByteReader{Reader: os.Stdin}},
 		Filters: []kio.Filter{
 			pkg.Fanout(
 				yaml.Tee(
-					pkg.SingleResourceLabelSelector(labelSelector),
+					pkg.SingleResourceTargeting(includes, excludes),
 					yaml.SetAnnotation(annotationName, value),
 				),
 			),

--- a/cmd/functions/label/main.go
+++ b/cmd/functions/label/main.go
@@ -28,14 +28,21 @@ func main() {
 		value = viper.GetString("value")
 	}
 
-	labelSelector := viper.GetString("label-selector")
+	includes := make([]pkg.TargetingFilter, 0)
+	if err := viper.UnmarshalKey("targets.includes", &includes); err != nil {
+		panic(fmt.Errorf("failed to unmarshal targeting includes: %w", err))
+	}
+	excludes := make([]pkg.TargetingFilter, 0)
+	if err := viper.UnmarshalKey("targets.excludes", &excludes); err != nil {
+		panic(fmt.Errorf("failed to unmarshal targeting excludes: %w", err))
+	}
 
 	pipeline := kio.Pipeline{
 		Inputs: []kio.Reader{&kio.ByteReader{Reader: os.Stdin}},
 		Filters: []kio.Filter{
 			pkg.Fanout(
 				yaml.Tee(
-					pkg.SingleResourceLabelSelector(labelSelector),
+					pkg.SingleResourceTargeting(includes, excludes),
 					yaml.SetLabel(labelName, value),
 				),
 			),

--- a/pkg/kyaml_targeting.go
+++ b/pkg/kyaml_targeting.go
@@ -1,0 +1,116 @@
+package pkg
+
+import (
+	"fmt"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+type TargetingFilter struct {
+	APIVersion    string `json:"apiVersion" yaml:"apiVersion"`
+	Kind          string `json:"kind" yaml:"kind"`
+	LabelSelector string `json:"labelSelector" yaml:"labelSelector"`
+}
+
+type multiResourceTargeting struct {
+	includes []TargetingFilter
+	excludes []TargetingFilter
+}
+
+func (s multiResourceTargeting) Filter(resources []*yaml.RNode) ([]*yaml.RNode, error) {
+	result := make([]*yaml.RNode, 0)
+	for _, resource := range resources {
+		included := len(s.includes) == 0
+		excluded := false
+		for _, f := range s.includes {
+			if f.APIVersion == "" || f.APIVersion == resource.GetApiVersion() {
+				if f.Kind == "" || f.Kind == resource.GetKind() {
+					if f.LabelSelector == "" {
+						included = true
+						break
+					} else if matches, err := resource.MatchesLabelSelector(f.LabelSelector); err != nil {
+						return nil, fmt.Errorf("resource '%s/%s' failed matching labels selector '%s': %w", resource.GetNamespace(), resource.GetName(), f.LabelSelector, err)
+					} else if matches {
+						included = true
+						break
+					}
+				}
+			}
+		}
+		for _, f := range s.excludes {
+			if f.APIVersion == "" || f.APIVersion == resource.GetApiVersion() {
+				if f.Kind == "" || f.Kind == resource.GetKind() {
+					if f.LabelSelector == "" {
+						excluded = true
+						break
+					} else if matches, err := resource.MatchesLabelSelector(f.LabelSelector); err != nil {
+						return nil, fmt.Errorf("resource '%s/%s' failed matching labels selector '%s': %w", resource.GetNamespace(), resource.GetName(), f.LabelSelector, err)
+					} else if matches {
+						excluded = true
+						break
+					}
+				}
+			}
+		}
+		if included && !excluded {
+			result = append(result, resource)
+		}
+	}
+	return result, nil
+}
+
+func MultiResourceTargeting(includes, excludes []TargetingFilter) kio.Filter {
+	return multiResourceTargeting{includes, excludes}
+}
+
+type singleResourceTargeting struct {
+	includes []TargetingFilter
+	excludes []TargetingFilter
+}
+
+func (s singleResourceTargeting) Filter(resource *yaml.RNode) (*yaml.RNode, error) {
+	included := len(s.includes) == 0
+	excluded := false
+
+	for _, f := range s.includes {
+		if f.APIVersion == "" || f.APIVersion == resource.GetApiVersion() {
+			if f.Kind == "" || f.Kind == resource.GetKind() {
+				if f.LabelSelector == "" {
+					included = true
+					break
+				} else if matches, err := resource.MatchesLabelSelector(f.LabelSelector); err != nil {
+					return nil, fmt.Errorf("resource '%s/%s' failed matching labels selector '%s': %w", resource.GetNamespace(), resource.GetName(), f.LabelSelector, err)
+				} else if matches {
+					included = true
+					break
+				}
+			}
+		}
+	}
+
+	for _, f := range s.excludes {
+		if f.APIVersion == "" || f.APIVersion == resource.GetApiVersion() {
+			if f.Kind == "" || f.Kind == resource.GetKind() {
+				if f.LabelSelector == "" {
+					excluded = true
+					break
+				} else if matches, err := resource.MatchesLabelSelector(f.LabelSelector); err != nil {
+					return nil, fmt.Errorf("resource '%s/%s' failed matching labels selector '%s': %w", resource.GetNamespace(), resource.GetName(), f.LabelSelector, err)
+				} else if matches {
+					excluded = true
+					break
+				}
+			}
+		}
+	}
+
+	if included && !excluded {
+		return resource, nil
+	} else {
+		return nil, nil
+	}
+}
+
+func SingleResourceTargeting(includes, excludes []TargetingFilter) yaml.Filter {
+	return singleResourceTargeting{includes, excludes}
+}


### PR DESCRIPTION
This change improves targeting of enrichment functions by allowing them to target resources based on API version, kind, and both inclusion or exclusion label selectors.

It also allows for multiple targeting per function, which allows "OR" style matching of resources.

Fixes #84 