### PR TITLE
Add codecov.yml to disable patch GitHub status

### DIFF
--- a/.github/workflows/build-commits.yml
+++ b/.github/workflows/build-commits.yml
@@ -99,7 +99,7 @@ jobs:
             golang-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
             golang-${{ runner.os }}-
       - run: go mod download
-      - run: go vet
+      - run: go vet ./...
       - run: |
           go test -ldflags "-X 'github.com/arikkfir/kude/pkg.gitCommit=${GITHUB_SHA}'" \
                   -v \

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  status:
+    patch: off

--- a/doc.go
+++ b/doc.go
@@ -1,1 +1,0 @@
-package kude


### PR DESCRIPTION
The codecov patch status represents the coverage for the changed lines
only, which can be misleading and prevent a PR from being merged
unjustly.

See: https://docs.codecov.com/docs/commit-status#patch-status