### PR TITLE
Use "mapstructure" struct tags for function configurations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ replace github.com/hashicorp/go-getter/v2 v2.1.0 => github.com/arikkfir/go-gette
 
 require (
 	github.com/arikkfir/gstream v0.0.1-alpha03
-	github.com/arikkfir/kyaml v0.0.1-alpha03
+	github.com/arikkfir/kyaml v0.0.1-beta01
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/docker/docker v20.10.17+incompatible
 	github.com/hashicorp/go-getter/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/arikkfir/go-getter/v2 v2.1.1-0.20220803160640-66abd65295a5 h1:mf+/pJC
 github.com/arikkfir/go-getter/v2 v2.1.1-0.20220803160640-66abd65295a5/go.mod h1:w65fE5glbccYjndAuj1kA5lnVBGZYEaH0e5qA1kpIks=
 github.com/arikkfir/gstream v0.0.1-alpha03 h1:CwU58wSywh/R7ztlWLBDaBjQSY+GmxQjd1GCouSqZRg=
 github.com/arikkfir/gstream v0.0.1-alpha03/go.mod h1:cW9kDIA9z2V9Rj3H/b9xQ8VeeF2YlJhMvH1rCu/Fdk4=
-github.com/arikkfir/kyaml v0.0.1-alpha03 h1:u9HiWC8rQD/LIaSBhPjQyGr0gGsGbmcpNDLJhsEoKSo=
-github.com/arikkfir/kyaml v0.0.1-alpha03/go.mod h1:MPEMBr459pPfgBOD1vPqA+pN4DTyn5GiG0lTZu5eZqg=
+github.com/arikkfir/kyaml v0.0.1-beta01 h1:XWbb4AIe9qdRte2fkKyEtHRaUPlOfcq3OTNw+ICN7Jk=
+github.com/arikkfir/kyaml v0.0.1-beta01/go.mod h1:MPEMBr459pPfgBOD1vPqA+pN4DTyn5GiG0lTZu5eZqg=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/internal/functions/builtin_annotate.go
+++ b/internal/functions/builtin_annotate.go
@@ -17,11 +17,11 @@ import (
 )
 
 type Annotate struct {
-	Name     string                  `json:"name" yaml:"name"`
-	Value    string                  `json:"value" yaml:"value"`
-	Path     string                  `json:"path" yaml:"path"`
-	Includes []kyaml.TargetingFilter `json:"includes" yaml:"includes"`
-	Excludes []kyaml.TargetingFilter `json:"excludes" yaml:"excludes"`
+	Name     string                  `mapstructure:"name"`
+	Value    string                  `mapstructure:"value"`
+	Path     string                  `mapstructure:"path"`
+	Includes []kyaml.TargetingFilter `mapstructure:"includes"`
+	Excludes []kyaml.TargetingFilter `mapstructure:"excludes"`
 }
 
 func (f *Annotate) Invoke(_ *log.Logger, pwd, _, _ string, r io.Reader, w io.Writer) error {

--- a/internal/functions/builtin_create_configmap.go
+++ b/internal/functions/builtin_create_configmap.go
@@ -18,16 +18,16 @@ import (
 )
 
 type CreateConfigMapEntry struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
-	Path  string `json:"path"`
+	Key   string `mapstructure:"key"`
+	Value string `mapstructure:"value"`
+	Path  string `mapstructure:"path"`
 }
 
 type CreateConfigMap struct {
-	Name      string                 `json:"name" yaml:"name"`
-	Namespace string                 `json:"namespace" yaml:"namespace"`
-	Immutable *bool                  `json:"immutable" yaml:"immutable"`
-	Contents  []CreateConfigMapEntry `json:"contents" yaml:"contents"`
+	Name      string                 `mapstructure:"name"`
+	Namespace string                 `mapstructure:"namespace"`
+	Immutable *bool                  `mapstructure:"immutable"`
+	Contents  []CreateConfigMapEntry `mapstructure:"contents"`
 }
 
 func (f *CreateConfigMap) Invoke(_ *log.Logger, pwd, _, _ string, r io.Reader, w io.Writer) error {

--- a/internal/functions/builtin_create_namespace.go
+++ b/internal/functions/builtin_create_namespace.go
@@ -12,7 +12,7 @@ import (
 )
 
 type CreateNamespace struct {
-	Name string `json:"name" yaml:"name"`
+	Name string `mapstructure:"name"`
 }
 
 func (f *CreateNamespace) Invoke(_ *log.Logger, _, _, _ string, r io.Reader, w io.Writer) error {

--- a/internal/functions/builtin_create_secret.go
+++ b/internal/functions/builtin_create_secret.go
@@ -19,17 +19,17 @@ import (
 )
 
 type CreateSecretEntry struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
-	Path  string `json:"path"`
+	Key   string `mapstructure:"key"`
+	Value string `mapstructure:"value"`
+	Path  string `mapstructure:"path"`
 }
 
 type CreateSecret struct {
-	Name      string              `json:"name" yaml:"name"`
-	Namespace string              `json:"namespace" yaml:"namespace"`
-	Immutable *bool               `json:"immutable" yaml:"immutable"`
-	Type      string              `json:"type" yaml:"type"`
-	Contents  []CreateSecretEntry `json:"contents" yaml:"contents"`
+	Name      string              `mapstructure:"name"`
+	Namespace string              `mapstructure:"namespace"`
+	Immutable *bool               `mapstructure:"immutable"`
+	Type      string              `mapstructure:"type"`
+	Contents  []CreateSecretEntry `mapstructure:"contents"`
 }
 
 func (f *CreateSecret) Invoke(_ *log.Logger, pwd, _, _ string, r io.Reader, w io.Writer) error {

--- a/internal/functions/builtin_helm.go
+++ b/internal/functions/builtin_helm.go
@@ -21,8 +21,8 @@ import (
 )
 
 type Helm struct {
-	Version string   `json:"version" yaml:"version"`
-	Args    []string `json:"args" yaml:"args"`
+	Version string   `mapstructure:"helm-version"`
+	Args    []string `mapstructure:"args"`
 }
 
 func (f *Helm) Invoke(logger *log.Logger, pwd, cacheDir, tempDir string, r io.Reader, w io.Writer) error {

--- a/internal/functions/builtin_label.go
+++ b/internal/functions/builtin_label.go
@@ -17,11 +17,11 @@ import (
 )
 
 type Label struct {
-	Name     string                  `json:"name" yaml:"name"`
-	Value    string                  `json:"value" yaml:"value"`
-	Path     string                  `json:"path" yaml:"path"`
-	Includes []kyaml.TargetingFilter `json:"includes" yaml:"includes"`
-	Excludes []kyaml.TargetingFilter `json:"excludes" yaml:"excludes"`
+	Name     string                  `mapstructure:"name"`
+	Value    string                  `mapstructure:"value"`
+	Path     string                  `mapstructure:"path"`
+	Includes []kyaml.TargetingFilter `mapstructure:"includes"`
+	Excludes []kyaml.TargetingFilter `mapstructure:"excludes"`
 }
 
 func (f *Label) Invoke(_ *log.Logger, pwd, _, _ string, r io.Reader, w io.Writer) error {

--- a/internal/functions/builtin_set_namespace.go
+++ b/internal/functions/builtin_set_namespace.go
@@ -15,9 +15,9 @@ import (
 )
 
 type SetNamespace struct {
-	Namespace string                  `json:"namespace" yaml:"namespace"`
-	Includes  []kyaml.TargetingFilter `json:"includes" yaml:"includes"`
-	Excludes  []kyaml.TargetingFilter `json:"excludes" yaml:"excludes"`
+	Namespace string                  `mapstructure:"namespace"`
+	Includes  []kyaml.TargetingFilter `mapstructure:"includes"`
+	Excludes  []kyaml.TargetingFilter `mapstructure:"excludes"`
 }
 
 func (f *SetNamespace) Invoke(_ *log.Logger, _, _, _ string, r io.Reader, w io.Writer) error {

--- a/internal/functions/builtin_yq.go
+++ b/internal/functions/builtin_yq.go
@@ -12,7 +12,7 @@ import (
 // TODO: download YQ into temp dir instead of bundling it inside the Docker image
 
 type YQ struct {
-	Expression string `json:"expression" yaml:"expression"`
+	Expression string `mapstructure:"expression"`
 }
 
 func (f *YQ) Invoke(logger *log.Logger, pwd, _, _ string, r io.Reader, w io.Writer) error {

--- a/pkg/testdata/scenario-helm-non-default-version.yaml
+++ b/pkg/testdata/scenario-helm-non-default-version.yaml
@@ -7,7 +7,8 @@ pipeline:
     - image: ghcr.io/arikkfir/kude/functions/helm
       network: true
       config:
-        helm-version: 3.8.1
+        helm-version: 3.8.0
+        helmVersion: 3.8.0
         args:
           - template
           - helm-remote-chart

--- a/pkg/testdata/scenario-helm-with-local-values-file.yaml
+++ b/pkg/testdata/scenario-helm-with-local-values-file.yaml
@@ -1,0 +1,138 @@
+apiVersion: kude.kfirs.com/v1alpha1
+kind: Scenario
+pipeline:
+  apiVersion: kude.kfirs.com/v1alpha2
+  kind: Pipeline
+  steps:
+    - image: ghcr.io/arikkfir/kude/functions/helm
+      network: true
+      config:
+        args:
+          - template
+          - helm-remote-chart
+          - podinfo
+          - --description=Test Helm Remote Chart
+          - --include-crds
+          - --namespace=test
+          - --repo=https://stefanprodan.github.io/podinfo
+          - --skip-tests
+          - --version=6.1.0
+          - --values=values.yaml
+      mounts:
+        - values.yaml
+
+resources:
+  values.yaml: |+
+    logLevel: info
+    nodeSelector:
+      purpose: podinfo
+
+expected: |+
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: helm-remote-chart-podinfo
+      app.kubernetes.io/version: 6.1.0
+      helm.sh/chart: podinfo-6.1.0
+    name: helm-remote-chart-podinfo
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: helm-remote-chart-podinfo
+    strategy:
+      rollingUpdate:
+        maxUnavailable: 1
+      type: RollingUpdate
+    template:
+      metadata:
+        annotations:
+          prometheus.io/port: "9898"
+          prometheus.io/scrape: "true"
+        labels:
+          app.kubernetes.io/name: helm-remote-chart-podinfo
+      spec:
+        containers:
+          - command:
+              - ./podinfo
+              - --port=9898
+              - --cert-path=/data/cert
+              - --port-metrics=9797
+              - --grpc-port=9999
+              - --grpc-service-name=podinfo
+              - --level=info
+              - --random-delay=false
+              - --random-error=false
+            env:
+              - name: PODINFO_UI_COLOR
+                value: '#34577c'
+            image: ghcr.io/stefanprodan/podinfo:6.1.0
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              exec:
+                command:
+                  - podcli
+                  - check
+                  - http
+                  - localhost:9898/healthz
+              initialDelaySeconds: 1
+              timeoutSeconds: 5
+            name: podinfo
+            ports:
+              - containerPort: 9898
+                name: http
+                protocol: TCP
+              - containerPort: 9797
+                name: http-metrics
+                protocol: TCP
+              - containerPort: 9999
+                name: grpc
+                protocol: TCP
+            readinessProbe:
+              exec:
+                command:
+                  - podcli
+                  - check
+                  - http
+                  - localhost:9898/readyz
+              initialDelaySeconds: 1
+              timeoutSeconds: 5
+            resources:
+              limits: null
+              requests:
+                cpu: 1m
+                memory: 16Mi
+            volumeMounts:
+              - mountPath: /data
+                name: data
+        nodeSelector:
+          purpose: podinfo
+        terminationGracePeriodSeconds: 30
+        volumes:
+          - emptyDir: {}
+            name: data
+  ---
+  apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: helm-remote-chart-podinfo
+      app.kubernetes.io/version: 6.1.0
+      helm.sh/chart: podinfo-6.1.0
+    name: helm-remote-chart-podinfo
+  spec:
+    ports:
+      - name: http
+        port: 9898
+        protocol: TCP
+        targetPort: http
+      - name: grpc
+        port: 9999
+        protocol: TCP
+        targetPort: grpc
+    selector:
+      app.kubernetes.io/name: helm-remote-chart-podinfo
+    type: ClusterIP

--- a/pkg/testdata/scenario-helm-with-no-values-file.yaml
+++ b/pkg/testdata/scenario-helm-with-no-values-file.yaml
@@ -7,7 +7,6 @@ pipeline:
     - image: ghcr.io/arikkfir/kude/functions/helm
       network: true
       config:
-        helm-version: 3.8.1
         args:
           - template
           - helm-remote-chart
@@ -18,15 +17,6 @@ pipeline:
           - --repo=https://stefanprodan.github.io/podinfo
           - --skip-tests
           - --version=6.1.0
-          - --values=values.yaml
-      mounts:
-        - values.yaml
-
-resources:
-  values.yaml: |+
-    logLevel: info
-    nodeSelector:
-      purpose: podinfo
 
 expected: |+
   apiVersion: apps/v1
@@ -108,8 +98,6 @@ expected: |+
             volumeMounts:
               - mountPath: /data
                 name: data
-        nodeSelector:
-          purpose: podinfo
         terminationGracePeriodSeconds: 30
         volumes:
           - emptyDir: {}


### PR DESCRIPTION
Since functions use Viper for configuration unmarshalling, and since Viper uses "mitchellh/mapstructure" library for unmarshalling, we need to use "mapstructure" tags in configuration Go structs.

This fixes the Helm version configuration.