### PR TITLE
Exclude non-namespaced objects in "set-namespace" function

### DIFF
--- a/internal/functions/builtin_set_namespace.go
+++ b/internal/functions/builtin_set_namespace.go
@@ -24,6 +24,11 @@ func (f *SetNamespace) Invoke(_ *log.Logger, _, _, _ string, r io.Reader, w io.W
 	if f.Namespace == "" {
 		return fmt.Errorf("the '%s' property is required for this function", "name")
 	}
+	f.Excludes = append(f.Excludes, kyaml.TargetingFilter{APIVersion: "v1", Kind: "Namespace"})
+	f.Excludes = append(f.Excludes, kyaml.TargetingFilter{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole"})
+	f.Excludes = append(f.Excludes, kyaml.TargetingFilter{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRoleBinding"})
+	f.Excludes = append(f.Excludes, kyaml.TargetingFilter{APIVersion: "admissionregistration.k8s.io/v1", Kind: "ValidatingWebhookConfiguration"})
+	f.Excludes = append(f.Excludes, kyaml.TargetingFilter{APIVersion: "apiextensions.k8s.io/v1", Kind: "CustomResourceDefinition"})
 
 	s := stream.NewStream().
 		Generate(FromReader(r)).

--- a/pkg/testdata/scenario-set-namespace-default-excludes.yaml
+++ b/pkg/testdata/scenario-set-namespace-default-excludes.yaml
@@ -1,0 +1,47 @@
+apiVersion: kude.kfirs.com/v1alpha1
+kind: Scenario
+pipeline:
+  apiVersion: kude.kfirs.com/v1alpha2
+  kind: Pipeline
+  resources:
+    - resources.yaml
+  steps:
+    - image: ghcr.io/arikkfir/kude/functions/set-namespace
+      config:
+        namespace: test
+        includes:
+          - name: t1
+
+resources:
+  resources.yaml: |-
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: ns
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: t1
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: t2
+
+expected: |-
+  apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: ns
+  ---
+  apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: t2
+  ---
+  apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: t1
+    namespace: test


### PR DESCRIPTION
This change excludes non-namespaced objects in the "set-namespace"
function.